### PR TITLE
Fixed active styles in InteractiveTabs.svelte

### DIFF
--- a/src/lib/tabs/InteractiveTabs.svelte
+++ b/src/lib/tabs/InteractiveTabs.svelte
@@ -36,13 +36,14 @@
 <div class="mb-4 border-b border-gray-200 dark:border-gray-700">
   <ul class="flex flex-wrap -mb-px" id={tabId} role="tablist">
     {#each tabs as { label, selected, id }}
-      <li class="mr-2" role="presentation" class:active={activeTabValue === id}>
+      <li class="mr-2" role="presentation">
         <button
           on:click={handleClick(id)}
           class="inline-block py-4 px-4 text-sm font-medium text-center text-gray-500 rounded-t-lg border-b-2 border-transparent hover:text-gray-600 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300"
           id="{label}-tab"
           type="button"
           role="tab"
+          class:active={activeTabValue === id}
           aria-controls={label}
           aria-selected={selected}>{label}</button
         >


### PR DESCRIPTION
The active class was used on the wrong element. Therefore the active tab was not highlighted.